### PR TITLE
Add native resolution, correction of parameters in process_data.sh

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -93,9 +93,9 @@ cd ${SUBJECT}/anat/
 # T1w
 # ------------------------------------------------------------------------------
 file_t1="${SUBJECT}_T1w"
-# Reorient to RPI and resample to 2.4 mm iso (supposed to be the effective resolution)
+# Reorient to RPI and resample to 1 mm iso (supposed to be the effective resolution)
 sct_image -i ${file_t1}.nii.gz -setorient RPI -o ${file_t1}_RPI.nii.gz
-sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz # supposed to be 2.4x2.4x2.4 ??
+sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz
 file_t1="${file_t1}_RPI_r"
 
 # Add gradient distorsion correction
@@ -127,9 +127,9 @@ sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile label_T1w/
 # T2
 # ------------------------------------------------------------------------------
 file_t2="${SUBJECT}_T2w"
-# Reorient to RPI and resample to 1mm iso (supposed to be the effective resolution) --> TODO change the resolution, not to 1mm...
+# Reorient to RPI and resample to 1mm iso (supposed to be the effective resolution)
 sct_image -i ${file_t2}.nii.gz -setorient RPI -o ${file_t2}_RPI.nii.gz
-sct_resample -i ${file_t2}_RPI.nii.gz -mm 0.8x0.8x0.8 -o ${file_t2}_RPI_r.nii.gz
+sct_resample -i ${file_t2}_RPI.nii.gz -mm 1x1x1 -o ${file_t2}_RPI_r.nii.gz
 file_t2="${file_t2}_RPI_r"
 
 #Add gradient distorsion correction


### PR DESCRIPTION
Fixes #4 

- Added the native resolution of the T1w and T2w images to sct_resample, 1x1x1 mm for both images in process_data.sh
- Modified sct_label_utils with parameter `-keep 3` 
- Modified sct_register_to_template  `- ldisc ${file_label}.nii.gz`
(as listed in issue #4 )
