### PR TITLE
Split processing into 2 scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Declare files that will always have LF line endings on checkout.
-*.sh text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Declare files that will always have LF line endings on checkout.
-*.sh text eol=lf
+*.sh text eol=crlf

--- a/README.md
+++ b/README.md
@@ -91,18 +91,26 @@ pip install -e ./
 ### Note on gradient distorsion correction
 A `coeff.grad` associated with the MRI scanner used for the data is necessary if it has not been applied yet. In this project, the gradient distorsion correction is done in `process_data.sh` with [gradunwrap v1.2.0](https://github.com/Washington-University/gradunwarp/tree/v1.2.0) and Siemens `coeff.grad` file.
 - - -
+### Preprocessing
+Initialize shell variable with the path to the folder with the `coeff.grad` file:
+~~~
+PATH_GRADCORR_FILE=<path-gradcorr>
+~~~
+Launch preprocessing:
+~~~
+sct_run_batch -jobs -1 -path-data <PATH-DATA> -path-output ~/ukbiobank_preprocess -script preprocess_data.sh -script-args $PATH_GRADCORR_FILE
+~~~
+
+TODO : create dataset with preprocessed data
 ### Usage
 Create a folder where the results will be generated:
 ~~~
 mkdir ~/ukbiobank_results
 ~~~
-Initialize shell variable with the path to the folder with the `coeff.grad` file:
-~~~
-PATH_GRADCORR_FILE=<path-gradcorr>
-~~~
+
 Launch processing:
 ~~~
-sct_run_batch -jobs -1 -path-data <PATH_DATA> -path-output ~/ukbiobank_results/ -script process_data.sh -script-args $PATH_GRADCORR_FILE
+sct_run_batch -jobs -1 -path-data <PATH_DATA> -path-output ~/ukbiobank_results/ -script process_data.sh
 ~~~
 
 Or you can launch processing with a config file instead by using the flag `-config` and by adjusting the file `config_sct_run_batch.yml` according to your setups.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ To convert the DICOM dataset in a BIDS structure for this project, run the follo
 ~~~
 curate_project.py -path-in <path_DICOM_dataset> -path-output <path_BIDS_dataset>
 ~~~
-The BIDS datset is (for now) in `duke: temp/uk_biobank_BIDS`
+The BIDS datset is (for now) in **|TODO : update with raw and processed repo**
 
-Here is an example of the BIDS data structure of UK biobank data:
+Here is an example of the BIDS data structure of UK biobank dataset:
 ~~~
-uk_biobank_BIDS
+uk-biobank
 │
 ├── participants.tsv
 ├── sub-1000032
@@ -45,12 +45,12 @@ uk_biobank_BIDS
         └── sub-1000710
             │
             └── anat
-                ├── sub-1000710_T1w_RPI_r_seg-manual.nii.gz  <---------- manually-corrected spinal cord segmentation
-                ├── sub-1000710_T1w_RPI_r_seg-manual.json  <------------ information about origin of segmentation
-                ├── sub-1000710_T1w_RPI_r_labels-manual.nii.gz  <------- manual vertebral labels
-                ├── sub-1000710_T1w_RPI_r_labels-manual.json
-                ├── sub-10007106_T2w_RPI_r_seg-manual.nii.gz  <---------- manually-corrected spinal cord segmentation
-                └── sub-1000710_T2w_RPI_r_seg-manual.json
+                ├── sub-1000710_T1w_seg-manual.nii.gz  <---------- manually-corrected spinal cord segmentation
+                ├── sub-1000710_T1w_seg-manual.json  <------------ information about origin of segmentation
+                ├── sub-1000710_T1w_labels-manual.nii.gz  <------- manual vertebral labels
+                ├── sub-1000710_T1w_labels-manual.json
+                ├── sub-10007106_T2w_seg-manual.nii.gz  <---------- manually-corrected spinal cord segmentation
+                └── sub-1000710_T2w_seg-manual.json
  
 ~~~
 
@@ -89,10 +89,12 @@ cd ukbiobank-spinalcord-csa
 pip install -e ./
 ~~~
 ### Note on gradient distorsion correction
-A `coeff.grad` associated with the MRI scanner used for the data is necessary if it has not been applied yet. In this project, the gradient distorsion correction is done in `process_data.sh` with [gradunwrap v1.2.0](https://github.com/Washington-University/gradunwarp/tree/v1.2.0) and Siemens `coeff.grad` file.
+A `coeff.grad` associated with the MRI scanner used for the data is necessary if it has not been applied yet. In this project, the gradient distorsion correction is done in `preprocess_data.sh` with [gradunwrap v1.2.0](https://github.com/Washington-University/gradunwarp/tree/v1.2.0) and Siemens `coeff.grad` file.
 - - -
 ### Preprocessing
-Initialize shell variable with the path to the folder with the `coeff.grad` file:
+Preprocessing generates a dataset with gradient distortion correction. 
+
+First, initialize shell variable with the path to the folder with the `coeff.grad` file:
 ~~~
 PATH_GRADCORR_FILE=<path-gradcorr>
 ~~~
@@ -101,12 +103,10 @@ Launch preprocessing:
 sct_run_batch -jobs -1 -path-data <PATH-DATA> -path-output ~/ukbiobank_preprocess -script preprocess_data.sh -script-args $PATH_GRADCORR_FILE
 ~~~
 
-TODO : create dataset with preprocessed data
-### Usage
-Create a folder where the results will be generated:
-~~~
-mkdir ~/ukbiobank_results
-~~~
+The results to use as the new dataset wil be in `~/ukbiobank_preprocess/data_processed/`.
+
+### Processing
+Processing will generate spinal cord segmentation, vertebral labels and compute cord CSA. Specify the path of preprocessed data with the flag `path-data`.
 
 Launch processing:
 ~~~
@@ -134,11 +134,11 @@ If segmentation or labeling issues are noticed while checking the quality report
 
 ~~~
 FILES_SEG:
-- sub-1000032_T1w_RPI_r_gradcorr.nii.gz
-- sub-1000083_T2w_RPI_r_gradcorr.nii.gz
+- sub-1000032_T1w.nii.gz
+- sub-1000083_T2w.nii.gz
 FILES_LABEL:
-- sub-1000032_T1w_RPI_r_gradcorr.nii.gz
-- sub-1000710_T1w_RPI_r_gradcorr.nii.gz
+- sub-1000032_T1w.nii.gz
+- sub-1000710_T1w.nii.gz
 ~~~
 
 * `FILES_SEG`: Images associated with spinal cord segmentation
@@ -155,13 +155,13 @@ C2-C3 disc label will be located at the posterior tip of the disc as shown in th
 ![alt text](https://user-images.githubusercontent.com/2482071/100895704-dabf4a00-348b-11eb-8b1c-67d5024bfeda.png)
 
 #### Upload the manually-corrected files
-A QC report of the manually correct files is created in a zip file. To update the database, follow this proceedure:
+A QC report of the manually correct files is created in a zip file. To update the dataset, follow this proceedure:
 * Commit and push manually-corrected files (placed in folders under `derivatives/labels/`
 * Create a pull request and add qc zip file in the body of the PR. 
 * If PR is accepted, a new release of the dataset will be created and the qc zip file will be uploaded as a release object.
 
 #### Re-run the analysis
-After all the necessary segmentation and labels are corrected, re-run the analysis (`sct_run_batch`command in **Usage** section). If manually-corrected files exists, they will be used intead of proceeding to automatic segmentation and labeling. Make sure to put the output results in another folder (flag `-path-output`) if you don't want the previous relsults to be overwritten.
+After all the necessary segmentation and labels are corrected, re-run the analysis (`sct_run_batch`command in **Processing** section). If manually-corrected files exists, they will be used intead of proceeding to automatic segmentation and labeling. Make sure to put the output results in another folder (flag `-path-output`) if you don't want the previous relsults to be overwritten.
 
 ### Statistical analysis
 #### Generate datafile:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ sct_run_batch -jobs -1 -path-data <PATH-DATA> -path-output ~/ukbiobank_preproces
 The results to use as the new dataset wil be in `~/ukbiobank_preprocess/data_processed/`.
 
 ### Processing
-Processing will generate spinal cord segmentation, vertebral labels and compute cord CSA. Specify the path of preprocessed data with the flag `path-data`.
+Processing will generate spinal cord segmentation, vertebral labels and compute cord CSA. Specify the path of preprocessed dataset with the flag `path-data`.
 
 Launch processing:
 ~~~

--- a/config_sct_run_batch.yml
+++ b/config_sct_run_batch.yml
@@ -2,7 +2,6 @@
 path_data: /scratch/sabeda/uk-biobank
 path_output: /scratch/sabeda/ukbiobank_results
 script: /home/sabeda/ukbiobank-spinalcord-csa/process_data.sh
-script_args: $PATH_GRADCORR_FILE
 jobs: -1
 batch_log: sct_run_batch_log.txt
 continue_on_error: 1

--- a/preprocess_data.sh
+++ b/preprocess_data.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 #
-# Preprocess data. From raw images, preceeds to resampling, reorientation, gradient distortion correction.
+# Preprocess data. From raw images, preceeds to resampling, reorientation and gradient distortion correction.
 # Usage:
 #   ./preprocess_data.sh <SUBJECT> <PATH_GRADCORR_FILE>
 #
 #
 # Authors: Sandrine Bédard, Julien Cohen-Adad
+
 set -x
 # Immediately exit if error
 set -e -o pipefail

--- a/preprocess_data.sh
+++ b/preprocess_data.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Preprocess data.
+# Preprocess data. From raw images, preceeds to resampling, reorientation, gradient distortion correction.
 # Usage:
 #   ./preprocess_data.sh <SUBJECT> <PATH_GRADCORR_FILE>
 #
@@ -52,14 +52,14 @@ sct_image -i ${file_t1}.nii.gz -setorient RPI -o ${file_t1}_RPI.nii.gz
 sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz
 file_t1="${file_t1}_RPI_r"
 
-# Gradient distorsion correction
+# Gradient distortion correction
 gradient_unwarp.py ${file_t1}.nii.gz ${file_t1}_gradcorr.nii.gz siemens -g ${PATH_GRADCORR_FILE}/coeff.grad -n
 file_t1="${file_t1}_gradcorr"
 
 # Rename gradcorr file
 mv ${file_t1}.nii.gz ${SUBJECT}_T1w.nii.gz
-# Delete raw, resampled and reoriented to RPI images
-rm -f ${SUBJECT}_T1w_raw.nii.gz ${SUBJECT}_T1w_raw_RPI.nii.gz ${SUBJECT}_T1w_raw_RPI_r.nii.gz # Remove f or not?
+# Delete raw, resampled and reoriented to RPI images and warp file from gradient distortion correction
+rm -f ${SUBJECT}_T1w_raw.nii.gz ${SUBJECT}_T1w_raw_RPI.nii.gz ${SUBJECT}_T1w_raw_RPI_r.nii.gz fullWarp_abs.nii.gz
 
 # T2w FLAIR
 # ------------------------------------------------------------------------------
@@ -73,14 +73,14 @@ sct_image -i ${file_t2}.nii.gz -setorient RPI -o ${file_t2}_RPI.nii.gz
 sct_resample -i ${file_t2}_RPI.nii.gz -mm 1x1x1 -o ${file_t2}_RPI_r.nii.gz
 file_t2="${file_t2}_RPI_r"
 
-# Gradient distorsion correction
+# Gradient distortion correction
 gradient_unwarp.py ${file_t2}.nii.gz ${file_t2}_gradcorr.nii.gz siemens -g ${PATH_GRADCORR_FILE}/coeff.grad -n
 file_t2="${file_t2}_gradcorr"
 
 # Rename gradcorr file
 mv ${file_t2}.nii.gz ${SUBJECT}_T2w.nii.gz
-# Delete raw, resampled and reoriented to RPI images
-rm -f ${SUBJECT}_T2w_raw.nii.gz ${SUBJECT}_T2w_raw_RPI.nii.gz ${SUBJECT}_T2w_raw_RPI_r.nii.gz # Remove f or not?
+# Delete raw, resampled and reoriented to RPI images and warp file from gradient distortion correction
+rm -f ${SUBJECT}_T2w_raw.nii.gz ${SUBJECT}_T2w_raw_RPI.nii.gz ${SUBJECT}_T2w_raw_RPI_r.nii.gz fullWarp_abs.nii.gz
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------

--- a/preprocess_data.sh
+++ b/preprocess_data.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Preprocess data.
+# Usage:
+#   ./preprocess_data.sh <SUBJECT> <PATH_GRADCORR_FILE>
+#
+#
+# Authors: Sandrine Bédard, Julien Cohen-Adad
+set -x
+# Immediately exit if error
+set -e -o pipefail
+
+# Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
+trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
+
+# Retrieve input params
+SUBJECT=$1
+PATH_GRADCORR_FILE=$2 
+
+# get starting time:
+start=`date +%s`
+
+# SCRIPT STARTS HERE
+# ==============================================================================
+# Display useful info for the log, such as SCT version, RAM and CPU cores available
+sct_check_dependencies -short
+
+# Go to folder where data will be copied and processed
+cd ${PATH_DATA_PROCESSED}
+# Copy list of participants in processed data folder
+if [[ ! -f "participants.tsv" ]]; then
+  rsync -avzh $PATH_DATA/participants.tsv .
+fi
+# Copy list of participants in resutls folder
+if [[ ! -f $PATH_RESULTS/"participants.tsv" ]]; then
+  rsync -avzh $PATH_DATA/participants.tsv $PATH_RESULTS/"participants.tsv"
+fi
+# Copy source images
+rsync -avzh $PATH_DATA/$SUBJECT .
+# Go to anat folder where all structural data are located
+cd ${SUBJECT}/anat/
+
+# T1w
+# ------------------------------------------------------------------------------
+file_t1="${SUBJECT}_T1w"
+# Rename the raw image
+mv ${file_t1}.nii.gz ${file_t1}_raw.nii.gz
+file_t1="${file_t1}_raw"
+
+# Reorient to RPI and resample to 1 mm iso (supposed to be the effective resolution)
+sct_image -i ${file_t1}.nii.gz -setorient RPI -o ${file_t1}_RPI.nii.gz
+sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz
+file_t1="${file_t1}_RPI_r"
+
+# Gradient distorsion correction
+gradient_unwarp.py ${file_t1}.nii.gz ${file_t1}_gradcorr.nii.gz siemens -g ${PATH_GRADCORR_FILE}/coeff.grad -n
+file_t1="${file_t1}_gradcorr"
+
+# Rename gradcorr file
+mv ${file_t1}.nii.gz ${SUBJECT}_T1w.nii.gz
+# Delete raw, resampled and reoriented to RPI images
+rm -f ${SUBJECT}_T1w_raw.nii.gz ${SUBJECT}_T1w_raw_RPI.nii.gz ${SUBJECT}_T1w_raw_RPI_r.nii.gz # Remove f or not?
+
+# T2w FLAIR
+# ------------------------------------------------------------------------------
+file_t2="${SUBJECT}_T2w"
+# Rename raw file
+mv ${file_t2}.nii.gz ${file_t2}_raw.nii.gz
+file_t2="${file_t2}_raw"
+
+# Reorient to RPI and resample to 1mm iso (supposed to be the effective resolution)
+sct_image -i ${file_t2}.nii.gz -setorient RPI -o ${file_t2}_RPI.nii.gz
+sct_resample -i ${file_t2}_RPI.nii.gz -mm 1x1x1 -o ${file_t2}_RPI_r.nii.gz
+file_t2="${file_t2}_RPI_r"
+
+# Gradient distorsion correction
+gradient_unwarp.py ${file_t2}.nii.gz ${file_t2}_gradcorr.nii.gz siemens -g ${PATH_GRADCORR_FILE}/coeff.grad -n
+file_t2="${file_t2}_gradcorr"
+
+# Rename gradcorr file
+mv ${file_t2}.nii.gz ${SUBJECT}_T2w.nii.gz
+# Delete raw, resampled and reoriented to RPI images
+rm -f ${SUBJECT}_T2w_raw.nii.gz ${SUBJECT}_T2w_raw_RPI.nii.gz ${SUBJECT}_T2w_raw_RPI_r.nii.gz # Remove f or not?
+
+# Verify presence of output files and write log file if error
+# ------------------------------------------------------------------------------
+FILES_TO_CHECK=(
+  "${SUBJECT}_T1w.nii.gz"
+  "${SUBJECT}_T2w.nii.gz"
+  
+)
+pwd
+for file in ${FILES_TO_CHECK[@]}; do
+  if [[ ! -e $file ]]; then
+    echo "${SUBJECT}/anat/${file} does not exist" >> $PATH_LOG/_error_check_output_files.log
+  fi
+done
+
+# Display useful info for the log
+end=`date +%s`
+runtime=$((end-start))
+echo
+echo "~~~"
+echo "SCT version: `sct_version`"
+echo "Ran on:      `uname -nsr`"
+echo "Duration:    $(($runtime / 3600))hrs $((($runtime / 60) % 60))min $(($runtime % 60))sec"
+echo "~~~"

--- a/process_data.sh
+++ b/process_data.sh
@@ -3,7 +3,7 @@
 # Process data.
 #
 # Usage:
-#   ./process_data.sh <SUBJECT> <PATH_GRADCORR_FILE>
+#   ./process_data.sh <SUBJECT>
 #
 # Manual segmentations or labels should be located under:
 # PATH_DATA/derivatives/labels/SUBJECT/anat/

--- a/process_data.sh
+++ b/process_data.sh
@@ -116,7 +116,7 @@ sct_flatten_sagittal -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz
 # Compute average cord CSA between C2 and C3
 sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile label_T1w/template/PAM50_levels.nii.gz -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
 
-# T2
+# T2w FLAIR
 # ------------------------------------------------------------------------------
 file_t2="${SUBJECT}_T2w"
 

--- a/process_data.sh
+++ b/process_data.sh
@@ -138,7 +138,7 @@ isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] 
 isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels2${file_t2}.nii.gz -n NearestNeighbor
 
 # Generate QC report to assess T1w registration to T2w
-sct_qc -i ${file_t1}_reg_mask.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t1}_reg.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Generate QC report to assess T2w vertebral labeling
 sct_qc -i ${file_t2}.nii.gz -s PAM50_levels2${file_t2}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}

--- a/process_data.sh
+++ b/process_data.sh
@@ -154,7 +154,6 @@ FILES_TO_CHECK=(
   "${SUBJECT}_T1w_labels.nii.gz"
   "label_T1w/template/PAM50_levels.nii.gz"
   "PAM50_levels2${SUBJECT}_T2w.nii.gz"
-  
 )
 pwd
 for file in ${FILES_TO_CHECK[@]}; do

--- a/process_data.sh
+++ b/process_data.sh
@@ -19,7 +19,7 @@ trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
 
 # Retrieve input params
 SUBJECT=$1
-PATH_GRADCORR_FILE=$2 
+PATH_GRADCORR_FILE=$2 #to remove
 
 # get starting time:
 start=`date +%s`
@@ -93,14 +93,6 @@ cd ${SUBJECT}/anat/
 # T1w
 # ------------------------------------------------------------------------------
 file_t1="${SUBJECT}_T1w"
-# Reorient to RPI and resample to 1 mm iso (supposed to be the effective resolution)
-sct_image -i ${file_t1}.nii.gz -setorient RPI -o ${file_t1}_RPI.nii.gz
-sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz
-file_t1="${file_t1}_RPI_r"
-
-# Gradient distorsion correction
-gradient_unwarp.py ${file_t1}.nii.gz ${file_t1}_gradcorr.nii.gz siemens -g ${PATH_GRADCORR_FILE}/coeff.grad -n
-file_t1="${file_t1}_gradcorr"
 
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist $file_t1 "t1"
@@ -127,14 +119,6 @@ sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile label_T1w/
 # T2
 # ------------------------------------------------------------------------------
 file_t2="${SUBJECT}_T2w"
-# Reorient to RPI and resample to 1mm iso (supposed to be the effective resolution)
-sct_image -i ${file_t2}.nii.gz -setorient RPI -o ${file_t2}_RPI.nii.gz
-sct_resample -i ${file_t2}_RPI.nii.gz -mm 1x1x1 -o ${file_t2}_RPI_r.nii.gz
-file_t2="${file_t2}_RPI_r"
-
-#Gradient distorsion correction
-gradient_unwarp.py ${file_t2}.nii.gz ${file_t2}_gradcorr.nii.gz siemens -g ${PATH_GRADCORR_FILE}/coeff.grad -n
-file_t2="${file_t2}_gradcorr"
 
 # Segment spinal cord (only if it does not exist)
 # Note: we specify the "t1" contrast for the automatic segmentation because the T2-FLAIR contrast is more similar to the T1 MPRAGE (this is due to the inversion recovery 'IR' in 'FLAIR' pulse which nulls the CSF signal)
@@ -165,13 +149,11 @@ sct_process_segmentation -i ${file_t2_seg}.nii.gz -vert 2:3 -vertfile PAM50_leve
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------
 FILES_TO_CHECK=(
-  "${SUBJECT}_T1w_RPI_r_gradcorr.nii.gz"
-  "${SUBJECT}_T2w_RPI_r_gradcorr.nii.gz"
-  "${SUBJECT}_T1w_RPI_r_gradcorr_seg.nii.gz" 
-  "${SUBJECT}_T2w_RPI_r_gradcorr_seg.nii.gz"
-  "${SUBJECT}_T1w_RPI_r_gradcorr_labels.nii.gz"
+  "${SUBJECT}_T1w_seg.nii.gz" 
+  "${SUBJECT}_T2w_seg.nii.gz"
+  "${SUBJECT}_T1w_labels.nii.gz"
   "label_T1w/template/PAM50_levels.nii.gz"
-  "PAM50_levels2${SUBJECT}_T2w_RPI_r_gradcorr.nii.gz"
+  "PAM50_levels2${SUBJECT}_T2w.nii.gz"
   
 )
 pwd


### PR DESCRIPTION
## Description
The purpose of this PR is to separtate processing from current  `process_data.sh` into two scripts:
* `preprocess_data.sh`:
    * Manages resampling, reorientation to RPI and gradient distorsion correction
    * The ouput of preprocessing will be the input data for processing (and the new dataset)
* `process_data.sh` (a revised version):
    * Proceeds to segmentation, vertebral labeling, computes cord CSA

Documentation was modified according to the new preprocessing step.
** Both scripts were tested on 2 and 30 subjects, no problem was noticed!
