### PR TITLE
Add exclude.yml list

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -1,0 +1,2 @@
+- sub-1005491_T2w.nii.gz # Don't see C2-3 disc, image tilted
+- sub-1024269_T1w.nii.gz # sc is blured and FOV cuts at C2-C3 disc

--- a/exclude.yml
+++ b/exclude.yml
@@ -1,2 +1,2 @@
-- sub-1005491_T2w.nii.gz # Don't see C2-3 disc, image tilted
+- sub-1005491_T2w.nii.gz  # Don't see C2-3 disc, image tilted
 - sub-1024269_T1w.nii.gz # sc is blured and FOV cuts at C2-C3 disc

--- a/exclude.yml
+++ b/exclude.yml
@@ -1,2 +1,2 @@
 - sub-1005491_T2w.nii.gz  # Don't see C2-3 disc, image tilted
-- sub-1024269_T1w.nii.gz # sc is blured and FOV cuts at C2-C3 disc
+- sub-1024269_T1w.nii.gz  # sc is blured and FOV cuts at C2-C3 disc


### PR DESCRIPTION
## Description
This PR adds `exclude.yml` which lists the images to exclude from the study due to poor data quality. The reason of exclusion is written next to the file name. This file is considered when running the statistics.

## Linked issue
Closes #37 