### PR TITLE
Bypass registration to PAM50 template in process_data.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Run the following line and specify the .yml list for vertebral labeling with the
 uk_manual_correction -config <.yml file> -path-in ~/ukbiobank_results/data_processed -path-out <PATH_DATA>
 ~~~
 
-To create disc labels, clic at the posterior tip of the disc for C1-C2, C2-C3 and C3-C4 as shown in the following image: 
+To create disc labels, click at the posterior tip of the disc for C1-C2, C2-C3 and C3-C4 as shown in the following image: 
 
 ![readme_labels](https://user-images.githubusercontent.com/71230552/111220077-18fdf680-85af-11eb-8ec4-4774db842a27.PNG)
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ Run the following line and specify the .yml list for vertebral labeling with the
 uk_manual_correction -config <.yml file> -path-in ~/ukbiobank_results/data_processed -path-out <PATH_DATA>
 ~~~
 
-C2-C3 disc label will be located at the posterior tip of the disc as shown in the following image. 
+To create disc labels, clic at the posterior tip of the disc for C1-C2, C2-C3 and C3-C4 as shown in the following image: 
 
-![alt text](https://user-images.githubusercontent.com/2482071/100895704-dabf4a00-348b-11eb-8b1c-67d5024bfeda.png)
+![readme_labels](https://user-images.githubusercontent.com/71230552/111220077-18fdf680-85af-11eb-8ec4-4774db842a27.PNG)
 
 #### Upload the manually-corrected files
 

--- a/pipeline_ukbiobank/cli/manual_correction.py
+++ b/pipeline_ukbiobank/cli/manual_correction.py
@@ -128,8 +128,8 @@ def correct_vertebral_labeling(fname, fname_label):
     :param name_rater:
     :return:
     """
-    message = "Click at the posterior tip of the disc between C2 and C3 vertebral levels, then click 'Save and Quit'."
-    os.system('sct_label_utils -i {} -create-viewer 3 -o {} -msg "{}"'.format(fname, fname_label, message))
+    message = "Click at the posterior tip of the disc between C1-C2, C2-C3 and C3-C4 vertebral levels, then click 'Save and Quit'."
+    os.system('sct_label_utils -i {} -create-viewer 2,3,4 -o {} -msg "{}"'.format(fname, fname_label, message))
 
 
 def create_json(fname_nifti, name_rater):

--- a/process_data.sh
+++ b/process_data.sh
@@ -145,9 +145,8 @@ sct_process_segmentation -i ${file_t2_seg}.nii.gz -vert 2:3 -vertfile ${file_t2}
 FILES_TO_CHECK=(
   "${SUBJECT}_T1w_seg.nii.gz" 
   "${SUBJECT}_T2w_seg.nii.gz"
-  "${SUBJECT}_T1w_labels.nii.gz"
-  "label_T1w/template/PAM50_levels.nii.gz"
-  "PAM50_levels2${SUBJECT}_T2w.nii.gz"
+  "${SUBJECT}_T1w_seg_labeled.nii.gz"
+  "${SUBJECT}_T2w_seg_labeled.nii.gz"
 )
 pwd
 for file in ${FILES_TO_CHECK[@]}; do

--- a/process_data.sh
+++ b/process_data.sh
@@ -29,7 +29,7 @@ start=`date +%s`
 
 # Check if manual label already exists. If it does, copy it locally. If it does
 # not, perform labeling.
-# NOTE: manual disc lables include C1-2, C2-3 and C3-4 dics.
+# NOTE: manual disc labels include C1-2, C2-3 and C3-4.
 label_if_does_not_exist(){
   local file="$1"
   local file_seg="$2"

--- a/process_data.sh
+++ b/process_data.sh
@@ -29,6 +29,7 @@ start=`date +%s`
 
 # Check if manual label already exists. If it does, copy it locally. If it does
 # not, perform labeling.
+# NOTE: manual disc lables include C1-2, C2-3 and C3-4 dics.
 label_if_does_not_exist(){
   local file="$1"
   local file_seg="$2"
@@ -39,7 +40,7 @@ label_if_does_not_exist(){
   if [[ -e $FILELABELMANUAL ]]; then
     echo "Found! Using manual labels."
     rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
-    # Generate labeled segmentation
+    # Generate labeled segmentation from manual disc labels
     sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz -c t1
   else
     echo "Not found. Proceeding with automatic labeling."
@@ -98,7 +99,7 @@ file_t1="${SUBJECT}_T1w"
 segment_if_does_not_exist $file_t1 "t1"
 file_t1_seg=$FILESEG
 
-# Create disc label at C1-C2, C2-C3 and C3-C4 (only if it does not exist) 
+# Create labeled segmentation (only if it does not exist) 
 label_if_does_not_exist ${file_t1} ${file_t1_seg}
 file_t1_seg_labeled="${file_t1_seg}_labeled"
 

--- a/process_data.sh
+++ b/process_data.sh
@@ -34,7 +34,6 @@ label_if_does_not_exist(){
   local file_seg="$2"
   # Update global variable with segmentation file name
   FILELABEL="${file}_labels"
-  #FILESEGLABELED="${file_seg}_labeled" to remove
   FILELABELMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT}/anat/${FILELABEL}-manual.nii.gz"
   echo "Looking for manual label: $FILELABELMANUAL"
   if [[ -e $FILELABELMANUAL ]]; then

--- a/process_data.sh
+++ b/process_data.sh
@@ -34,17 +34,18 @@ label_if_does_not_exist(){
   local file_seg="$2"
   # Update global variable with segmentation file name
   FILELABEL="${file}_labels"
+  #FILESEGLABELED="${file_seg}_labeled" to remove
   FILELABELMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT}/anat/${FILELABEL}-manual.nii.gz"
   echo "Looking for manual label: $FILELABELMANUAL"
   if [[ -e $FILELABELMANUAL ]]; then
     echo "Found! Using manual labels."
     rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
+    # Generate labeled segmentation
+    sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz
   else
     echo "Not found. Proceeding with automatic labeling."
     # Generate labeled segmentation
     sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -c t1
-    # Create label at the C2-C3 intervertebral disc
-    sct_label_utils -i ${file_seg}_labeled_discs.nii.gz -keep 3 -o ${FILELABEL}.nii.gz
   fi
 }
 
@@ -98,23 +99,16 @@ file_t1="${SUBJECT}_T1w"
 segment_if_does_not_exist $file_t1 "t1"
 file_t1_seg=$FILESEG
 
-# Create label at the C2-C3 intervertebral disc (only if it does not exist) 
+# Create disc label at C1-C2, C2-C3 and C3-C4 (only if it does not exist) 
 label_if_does_not_exist ${file_t1} ${file_t1_seg}
+file_t1_seg_labeled="${file_t1_seg}_labeled"
 
-file_label=$FILELABEL
-# Register to PAM50 template
-sct_register_to_template -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -ldisc ${file_label}.nii.gz -c t1 -param step=1,type=seg,algo=centermassrot:step=2,type=seg,algo=syn,slicewise=1,smooth=0,iter=5:step=3,type=im,algo=syn,slicewise=1,smooth=0,iter=3 -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# Rename warping fields for clarity
-mv warp_template2anat.nii.gz warp_template2T1w.nii.gz
-mv warp_anat2template.nii.gz warp_T1w2template.nii.gz
-# Warp template without the white matter atlas (we don't need it at this point)
-sct_warp_template -d ${file_t1}.nii.gz -w warp_template2T1w.nii.gz -a 0 -ofolder label_T1w
 # Generate QC report to assess vertebral labeling
-sct_qc -i ${file_t1}.nii.gz -s label_T1w/template/PAM50_levels.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg_labeled}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
 # Flatten scan along R-L direction (to make nice figures)
 sct_flatten_sagittal -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz
 # Compute average cord CSA between C2 and C3
-sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile label_T1w/template/PAM50_levels.nii.gz -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
+sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile ${file_t1_seg_labeled}.nii.gz -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
 
 # T2w FLAIR
 # ------------------------------------------------------------------------------
@@ -135,16 +129,16 @@ ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 40
 isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
 
 # Apply transformation to T1w vertebral level
-isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels2${file_t2}.nii.gz -n NearestNeighbor
+isct_antsApplyTransforms -i ${file_t1_seg_labeled}.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o ${file_t2}_seg_labeled.nii.gz -n NearestNeighbor
 
 # Generate QC report to assess T1w registration to T2w
-sct_qc -i ${file_t1}_reg.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t1}_reg.nii.gz -s ${file_t2}_seg_labeled.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Generate QC report to assess T2w vertebral labeling
-sct_qc -i ${file_t2}.nii.gz -s PAM50_levels2${file_t2}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_qc -i ${file_t2}.nii.gz -s ${file_t2}_seg_labeled.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Compute average cord CSA between C2 and C3
-sct_process_segmentation -i ${file_t2_seg}.nii.gz -vert 2:3 -vertfile PAM50_levels2${file_t2}.nii.gz -o ${PATH_RESULTS}/csa-SC_T2w.csv -append 1
+sct_process_segmentation -i ${file_t2_seg}.nii.gz -vert 2:3 -vertfile ${file_t2}_seg_labeled.nii.gz -o ${PATH_RESULTS}/csa-SC_T2w.csv -append 1
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------

--- a/process_data.sh
+++ b/process_data.sh
@@ -41,7 +41,7 @@ label_if_does_not_exist(){
     echo "Found! Using manual labels."
     rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
     # Generate labeled segmentation
-    sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz
+    sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz -c t1
   else
     echo "Not found. Proceeding with automatic labeling."
     # Generate labeled segmentation


### PR DESCRIPTION
## Description
This PR modifies the processing pipeline `process_data.sh` to bypass registration to PAM50 template which is not necessary for the purpose of this project (see #44). 

This PR includes:
* `process_data.sh` was modified to bypass PAM50 template, creates labeled segmentations directly (for automatic and manual disc labels).
* Manual disc labeling now includes C1-2, C2-3 and C3-4  (instead of only C2-3) --> not that much longer and can be useful. 
    * `manual_correction.py` now creates the viewer in `sct_label_utils`  for  C1-2, C2-3 and C3-4.
    * Manual labeling instructions in `README.md` were modified to indicate the user to label  C1-2, C2-3 and C3-4 instead of just C2-3.

## Linked issue
Closes #44