### PR TITLE
add sub to exclude from QC: sub-1025351 to sub-1047836

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -1,9 +1,9 @@
 - sub-1005491_T2w.nii.gz  # Don't see C2-3 disc, image tilted
 - sub-1011687_T2w.nii.gz  # Shading arround C2-C3, can't see SC
+- sub-1012113_T1w.nii.gz  # FOV cuts before C2-C3 disc
 - sub-1016730_T2w.nii.gz  # Shading arround C2-C3, can't see SC
 - sub-1017825_T2w.nii.gz  # Shading, can't see SC , image tiled
 - sub-1024269_T1w.nii.gz  # SC is blured and FOV cuts at C2-C3 disc
-- sub-1012113_T1w.nii.gz  # FOV cuts before C2-C3 disc
 - sub-1026594_T2w.nii.gz  # No contrast arround SC at C2-C3
 - sub-1027132_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1027567_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc

--- a/exclude.yml
+++ b/exclude.yml
@@ -2,5 +2,28 @@
 - sub-1011687_T2w.nii.gz  # Shading arround C2-C3, can't see SC
 - sub-1016730_T2w.nii.gz  # Shading arround C2-C3, can't see SC
 - sub-1017825_T2w.nii.gz  # Shading, can't see SC , image tiled
-- sub-1024269_T1w.nii.gz  # sc is blured and FOV cuts at C2-C3 disc
+- sub-1024269_T1w.nii.gz  # SC is blured and FOV cuts at C2-C3 disc
 - sub-1012113_T1w.nii.gz  # FOV cuts before C2-C3 disc
+- sub-1026594_T2w.nii.gz  # No contrast arround SC at C2-C3
+- sub-1027132_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1027567_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1029324_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1029729_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1029993_T2w.nii.gz  # Image tilted + shading, don't see SC + disc
+- sub-1030519_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1031426_T1w.nii.gz  # Motion artifact
+- sub-1031426_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1031952_T2w.nii.gz  # Image tilted + shading, don't see SC + disc
+- sub-1035680_T2w.nii.gz  # Shading at C2-C3
+- sub-1035863_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1036337_T2w.nii.gz  # FOV cuts SC
+- sub-1036523_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1036748_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1038735_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1039751_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1040099_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1040988_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1041624_T2w.nii.gz  # Shading of SC, don't see SC + disc
+- sub-1045181_T2w.nii.gz  # Shading + poor data quality
+- sub-1046534_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1047654_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc


### PR DESCRIPTION
## Description
This PR adds images to exclude from the analysis from what Olivier observed in QC report from the first 350 subjects of UK Biobank. It refers to subjects from `sub-1025351` to `sub-1047836`. 

I looked at all the images and the main issue is for T2w images: shading appears on SC, so we don't see it --> see [issue # 45](https://github.com/sct-pipeline/ukbiobank-spinalcord-csa/issues/45)
This problem is identified as `# Shading at C2-C3, don't see SC + disc` in `exclude .yml`. (Can be changed if it is unclear)