### PR TITLE
add subjects to exclude from sub-1000032 to sub-1025290

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -1,8 +1,26 @@
 - sub-1005491_T2w.nii.gz  # Don't see C2-3 disc, image tilted
-- sub-1011687_T2w.nii.gz  # Shading arround C2-C3, can't see SC
+- sub-1006023_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc 
+- sub-1007450_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1007915_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1010982_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc --> automatic defacing problem
+- sub-1011687_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1012113_T1w.nii.gz  # FOV cuts before C2-C3 disc
+- sub-1012113_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1015344_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1016730_T1w.nii.gz  # Image tilted + poor contrast at C2-C3 of SC
 - sub-1016730_T2w.nii.gz  # Shading arround C2-C3, can't see SC
-- sub-1017825_T2w.nii.gz  # Shading, can't see SC , image tiled
+- sub-1017582_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1017825_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1018786_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1018932_T1w.nii.gz  # Poor contrast of SC arround C2-C3 + image tilted
+- sub-1018932_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1019867_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1021125_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1021191_T1w.nii.gz  # Motion artefact
+- sub-1021534_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1022232_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1023062_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1024889_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1024269_T1w.nii.gz  # SC is blured and FOV cuts at C2-C3 disc
 - sub-1026594_T2w.nii.gz  # No contrast arround SC at C2-C3
 - sub-1027132_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc


### PR DESCRIPTION
## Description
This PR adds images to exclude from the analysis to `exclude.yml`  from what Étienne observed in the QC report from the first 350 subjects of UK Biobank. It refers to subjects from `sub-1000032` to `sub-1025290`.

I looked at all images and the main issue is still shading of the spinal cord in T2w images (see [issue #45 ](https://github.com/sct-pipeline/ukbiobank-spinalcord-csa/issues/45))