### PR TITLE
Add manually qc-ed automatic segmentations to derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ To create disc labels, click at the posterior tip of the disc for C1-C2, C2-C3 a
 A QC report of the manually corrected files is created in a zip file. To update the dataset, add all manually-corrected files `derivatives/labels/`,  and include the qc zip file in the body of the PR. See our [internal procedure](https://github.com/neuropoly/data-management/blob/master/internal-server.md#upload) for more details.
 **TODO see if it is possible to inlcude the qc zipe file in PR** 
 
+#### Add automatic segmentations to `derivatives/` folder
+After all segmentations are manually QC-ed, you can add them to the `derivatives/` by running again the script `manual_correction.py` and adding the flag `-add-seg-only`:
+~~~
+uk_manual_correction -config <.yml file> -path-in ~/ukbiobank_results/data_processed -path-out <PATH_DATA> -add-seg-only
+~~~
+The automatic segmentations that did not require manual correction (files in .yml file) are added to the `derivatives/` folder. You can upload the folder following the instructions specified in [Upload the manually-corrected files](#upload-the-manually-corrected-files).
+
 #### Re-run the analysis
 After all the necessary segmentation and labels are corrected, re-run the analysis (`sct_run_batch` command in [Processing](#processing)). If manually-corrected files exist, they will be used instead of proceeding to automatic segmentation and labeling. Make sure to put the output results in another folder (flag `-path-output`) if you don't want the previous results to be overwritten. 
 

--- a/pipeline_ukbiobank/cli/manual_correction.py
+++ b/pipeline_ukbiobank/cli/manual_correction.py
@@ -76,9 +76,9 @@ def get_parser():
         action='store_true'
     )
     parser.add_argument(
-        '-add-seg-only', # Find a better flag name
-        help="Only copies segmentation files that aren't in -config list and adds them to the derivatives/ folder. "
-             "This flag is to add manually QC-ed automatic segmentations to the derivatives folder.",
+        '-add-seg-only',
+        help="Only copy the source files (segmentation) that aren't in -config list to the derivatives/ folder. "
+             "Use this flag to add manually QC-ed automatic segmentations to the derivatives folder.",
         action='store_true'
     )
     parser.add_argument(
@@ -194,13 +194,13 @@ def main():
     # Get list of segmentations files for all subjects in -path-in (if -add-seg-only)
     if args.add_seg_only:
         path_list = glob.glob(args.path_in + "/**/*seg.nii.gz", recursive = True) # TODO: add other extension
-        # Get only filename without _seg suffix to match files in -config .yml list
+        # Get only filenames without suffix _seg  to match files in -config .yml list
         file_list = [utils.remove_suffix(os.path.split(path)[-1], '_seg') for path in path_list]
 
     # TODO: address "none" issue if no file present under a key
     # Perform manual corrections
     for task, files in dict_yml.items():
-        # Get the list of segmentation files to add to derivatives, excluding the manually corrrected files.
+        # Get the list of segmentation files to add to derivatives, excluding the manually corrrected files in -config.
         if args.add_seg_only and task=='FILES_SEG':
             # Remove the files in the -config list
             for file in files:

--- a/pipeline_ukbiobank/cli/manual_correction.py
+++ b/pipeline_ukbiobank/cli/manual_correction.py
@@ -177,7 +177,7 @@ def main():
         except yaml.YAMLError as exc:
             print(exc)
 
-    # check for missing files before starting the whole process | !!
+    # check for missing files before starting the whole process
     utils.check_files_exist(dict_yml, args.path_in)
 
     # check that output folder exists and has write permission

--- a/pipeline_ukbiobank/cli/manual_correction.py
+++ b/pipeline_ukbiobank/cli/manual_correction.py
@@ -193,7 +193,7 @@ def main():
 
     # Get list of segmentations files for all subjects in -path-in (if -add-seg-only)
     if args.add_seg_only:
-        path_list = glob.glob(args.path_in + "/**/*seg.nii.gz", recursive = True) # TODO: add other extension
+        path_list = glob.glob(args.path_in + "/**/*seg.nii.gz", recursive=True) # TODO: add other extension
         # Get only filenames without suffix _seg  to match files in -config .yml list
         file_list = [utils.remove_suffix(os.path.split(path)[-1], '_seg') for path in path_list]
 

--- a/pipeline_ukbiobank/cli/manual_correction.py
+++ b/pipeline_ukbiobank/cli/manual_correction.py
@@ -75,6 +75,12 @@ def get_parser():
         action='store_true'
     )
     parser.add_argument(
+        '-add-only', # Find a better flag name
+        help="Only copies segmentation files that aren't in -config list and adds them to the derivatives/ folder. "
+             "This flag is to add manually QC-ed automatic segmentations to the derivatives folder.",
+        action='store_true'
+    )
+    parser.add_argument(
         '-v', '--verbose',
         help="Full verbose (for debugging)",
         action='store_true'

--- a/pipeline_ukbiobank/utils.py
+++ b/pipeline_ukbiobank/utils.py
@@ -83,21 +83,7 @@ class SmartFormatter(argparse.HelpFormatter):
             return wrapped
         return argparse.HelpFormatter._split_lines(self, text, width)
 
-def add_suffix(fname, suffix):
-    """
-    Add suffix between end of file name and extension.
-
-    :param fname: absolute or relative file name. Example: t2.nii
-    :param suffix: suffix. Example: _mean
-    :return: file name with suffix. Example: t2_mean.nii
-
-    Examples:
-
-    - add_suffix(t2.nii, _mean) -> t2_mean.nii
-    - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
-    """
-
-    def _splitext(fname):
+def splitext(fname):
         """
         Split a fname (folder/file + ext) into a folder/file and extension.
 
@@ -113,8 +99,27 @@ def add_suffix(fname, suffix):
         stem, ext = os.path.splitext(filename)
         return os.path.join(dir, stem), ext
 
-    stem, ext = _splitext(fname)
+def add_suffix(fname, suffix):
+    """
+    Add suffix between end of file name and extension.
+
+    :param fname: absolute or relative file name. Example: t2.nii
+    :param suffix: suffix. Example: _mean
+    :return: file name with suffix. Example: t2_mean.nii
+
+    Examples:
+
+    - add_suffix(t2.nii, _mean) -> t2_mean.nii
+    - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
+    """
+    stem, ext = splitext(fname)
     return os.path.join(stem + suffix + ext)
+
+
+def remove_suffix(fname, suffix): # TODO: commenter
+    stem, ext = splitext(fname)
+    return os.path.join(stem.replace(suffix, '') + ext)
+
 
 def check_files_exist(dict_files, path_data):
     """

--- a/pipeline_ukbiobank/utils.py
+++ b/pipeline_ukbiobank/utils.py
@@ -116,7 +116,19 @@ def add_suffix(fname, suffix):
     return os.path.join(stem + suffix + ext)
 
 
-def remove_suffix(fname, suffix): # TODO: commenter
+def remove_suffix(fname, suffix):
+    """
+    Remove suffix between end of file name and extension.
+
+    :param fname: absolute or relative file name with suffix. Example: t2_mean.nii
+    :param suffix: suffix. Example: _mean
+    :return: file name without suffix. Example: t2.nii
+
+    Examples:
+
+    - remove_suffix(t2_mean.nii, _mean) -> t2.nii
+    - remove_suffix(t2a.nii.gz, a) -> t2.nii.gz
+    """
     stem, ext = splitext(fname)
     return os.path.join(stem.replace(suffix, '') + ext)
 

--- a/pipeline_ukbiobank/utils.py
+++ b/pipeline_ukbiobank/utils.py
@@ -30,6 +30,7 @@ def get_contrast(file):
     """
     return 'anat'
 
+
 class SmartFormatter(argparse.HelpFormatter):
     """
     Custom formatter that inherits from HelpFormatter, which adjusts the default width to the current Terminal size,
@@ -83,6 +84,7 @@ class SmartFormatter(argparse.HelpFormatter):
             return wrapped
         return argparse.HelpFormatter._split_lines(self, text, width)
 
+
 def splitext(fname):
         """
         Split a fname (folder/file + ext) into a folder/file and extension.
@@ -98,6 +100,7 @@ def splitext(fname):
         # If no special case, behaves like the regular splitext
         stem, ext = os.path.splitext(filename)
         return os.path.join(dir, stem), ext
+
 
 def add_suffix(fname, suffix):
     """


### PR DESCRIPTION
## Description
This PR addresses the issue https://github.com/sct-pipeline/ukbiobank-spinalcord-csa/issues/51. It includes the modification of `manual_correction.py` to add an option to add the segmentations not in the `-config` list to the derivatives folder, add suffix `-manual` and create json sidecar.

**Notes:**
* This option is only available for segmentations and not for vertebral lableing because we don't create automatically C1-2, C2-3 and C3-4 disc labeling (which we do for manual labeling).
* T2w segmentations will also be added if they are available. This will only be the case for the first 350 subjects (T2w segmentations are already manually qc-ed).  

More precisely:
* Adds the flag `-add-seg-only` to`manual_correction.py`
* Gets the list of filenames that have segmentations
* Excludes the files in `-config` list from the files to add to derivatives
* Copies source file, adds suffix `-manual`and creates json sidecar (as for normal usage of `manual_correction.py` for segmentations) but no interactive window is open
* The function `remove_suffix ` was added to `utils.py` to remove the suffix `_seg` to get a list of files as we have in `-config` flag in `manual_correction.py` (this way the same loop can be used)
* The instructions to use this option were added to `README`

## Linked issue
Closes #51 