### PR TITLE
Add subjects to exclude from next 650 subjects

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -49,3 +49,30 @@
 - sub-1045181_T2w.nii.gz  # Shading + poor data quality
 - sub-1046534_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1047654_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1048407_T1w.nii.gz  # Poor data quality
+- sub-1048812_T1w.nii.gz  # Motion artefact
+- sub-1052029_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1059011_T1w.nii.gz  # Motion artefact
+- sub-1067736_T1w.nii.gz  # Motion artefact
+- sub-1070818_T1w.nii.gz  # Motion artefact + poor data quality
+- sub-1078395_T1w.nii.gz  # Motion artefact
+- sub-1080952_T1w.nii.gz  # Motion artefact
+- sub-1081070_T1w.nii.gz  # Motion artefact
+- sub-1091250_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1094289_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1098459_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1102439_T1w.nii.gz  # Motion artefact  
+- sub-1113753_T1w.nii.gz  # Motion artefact
+- sub-1115141_T1w.nii.gz  # Poor data quality
+- sub-1122338_T1w.nii.gz  # Motion artefact
+- sub-1123856_T1w.nii.gz  # Motion artefact
+- sub-1125665_T1w.nii.gz  # Motion artefact
+- sub-1127471_T1w.nii.gz  # Motion artefact + poor data quality
+- sub-1132220_T1w.nii.gz  # Motion artefact
+- sub-1133658_T1w.nii.gz  # Motion artefact
+- sub-1136053_T1w.nii.gz  # Motion artefact + poor data quality
+- sub-1139207_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3
+- sub-1139656_T1w.nii.gz  # Poor data quality arround C2-C3
+- sub-1139906_T1w.nii.gz  # Poor data quality just bellow C2-3
+- sub-1140969_T1w.nii.gz  # Poor data quality at C2-3 disc
+- sub-1141536_T1w.nii.gz  # FOV cuts C2-C3 disc


### PR DESCRIPTION
## Description
This PR adds 27 images to `exclude.yml` from the next 650 subjects of UK Biobank. 

Main reasons for excluding are:
* FOV cuts C2-3 disc:
![image](https://user-images.githubusercontent.com/71230552/113233434-35678780-926d-11eb-98ba-4e8bfaf360aa.png)

* Motion artefact
![image](https://user-images.githubusercontent.com/71230552/113233610-a313b380-926d-11eb-9fd9-62020534a9f2.png)

* Poor data quality

![image](https://user-images.githubusercontent.com/71230552/113233749-ec640300-926d-11eb-8258-dab1482482f3.png)
