### PR TITLE
Add tutorial for manual vertebral labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ After all corrections are done, you can generate a QC report by adding the flag 
 #### 3. Vertebral labeling
 Note that manual labeling uses SCT and the QC report is generated automatically.
 
+Here is a tutorial for manual vertebral labeling:
+
+[![IMAGE ALT TEXT](http://img.youtube.com/vi/ycUrm97nW1A/sddefault.jpg)](https://youtu.be/ycUrm97nW1A "Correcting vertebral labeling across multiple subjects")
+
 Run the following line and specify the .yml list for vertebral labeling with the flag `-config`:
 ~~~
 uk_manual_correction -config <.yml file> -path-in ~/ukbiobank_results/data_processed -path-out <PATH_DATA>


### PR DESCRIPTION
## Description
This PR adds a tutorial for correcting vertebral lableling in the README.

Since all documentation for vertebral labeling is now up ot date, we can close #14 .
## Linked issue
Closes #14 