### PR TITLE
Add subjects to exclude

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -62,7 +62,6 @@
 - sub-1081070_T1w.nii.gz  # Motion artefact
 - sub-1091250_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1094289_T1w.nii.gz  # FOV cuts C2-C3 disc
-- sub-1097741_T1w.nii.gz  # Poor data quality at C2-3
 - sub-1098459_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1102439_T1w.nii.gz  # Motion artefact  
 - sub-1113753_T1w.nii.gz  # Motion artefact

--- a/exclude.yml
+++ b/exclude.yml
@@ -51,6 +51,7 @@
 - sub-1047654_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1048407_T1w.nii.gz  # Poor data quality
 - sub-1048812_T1w.nii.gz  # Motion artefact
+- sub-1052980_T1w.nii.gz  # Poor data quality
 - sub-1052029_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1059011_T1w.nii.gz  # Motion artefact
 - sub-1067736_T1w.nii.gz  # Motion artefact
@@ -73,7 +74,6 @@
 - sub-1127471_T1w.nii.gz  # Motion artefact + poor data quality
 - sub-1132109_T1w.nii.gz  # Poor data quality
 - sub-1132220_T1w.nii.gz  # Motion artefact
-- sub-1132718_T1w.nii.gz  # Poor data quality
 - sub-1133024_T1w.nii.gz  # Poor data quality
 - sub-1133658_T1w.nii.gz  # Motion artefact
 - sub-1136053_T1w.nii.gz  # Motion artefact + poor data quality

--- a/exclude.yml
+++ b/exclude.yml
@@ -70,9 +70,8 @@
 - sub-1123856_T1w.nii.gz  # Motion artefact
 - sub-1125665_T1w.nii.gz  # Motion artefact
 - sub-1127471_T1w.nii.gz  # Motion artefact + poor data quality
-- sub-1132109_T1w.nii.gz  # Poor data quality
 - sub-1132220_T1w.nii.gz  # Motion artefact
-- sub-1133024_T1w.nii.gz  # Poor data quality
+- sub-1133024_T1w.nii.gz  # Poor data quality + motion
 - sub-1133658_T1w.nii.gz  # Motion artefact
 - sub-1136053_T1w.nii.gz  # Motion artefact + poor data quality
 - sub-1139207_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3

--- a/exclude.yml
+++ b/exclude.yml
@@ -62,7 +62,6 @@
 - sub-1081070_T1w.nii.gz  # Motion artefact
 - sub-1091250_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1094289_T1w.nii.gz  # FOV cuts C2-C3 disc
-- sub-1095748_T1w.nii.gz  # Poor data quality + motion
 - sub-1097741_T1w.nii.gz  # Poor data quality at C2-3
 - sub-1098459_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1102439_T1w.nii.gz  # Motion artefact  

--- a/exclude.yml
+++ b/exclude.yml
@@ -52,7 +52,6 @@
 - sub-1048407_T1w.nii.gz  # Poor data quality
 - sub-1048812_T1w.nii.gz  # Motion artefact
 - sub-1052029_T1w.nii.gz  # FOV cuts C2-C3 disc
-- sub-1052980_T1w.nii.gz  # Poor data quality
 - sub-1059011_T1w.nii.gz  # Motion artefact
 - sub-1067736_T1w.nii.gz  # Motion artefact
 - sub-1070818_T1w.nii.gz  # Motion artefact + poor data quality

--- a/exclude.yml
+++ b/exclude.yml
@@ -52,14 +52,18 @@
 - sub-1048407_T1w.nii.gz  # Poor data quality
 - sub-1048812_T1w.nii.gz  # Motion artefact
 - sub-1052029_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1052980_T1w.nii.gz  # Poor data quality
 - sub-1059011_T1w.nii.gz  # Motion artefact
 - sub-1067736_T1w.nii.gz  # Motion artefact
 - sub-1070818_T1w.nii.gz  # Motion artefact + poor data quality
+- sub-1077193_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3
 - sub-1078395_T1w.nii.gz  # Motion artefact
 - sub-1080952_T1w.nii.gz  # Motion artefact
 - sub-1081070_T1w.nii.gz  # Motion artefact
 - sub-1091250_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1094289_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1095748_T1w.nii.gz  # Poor data quality + motion
+- sub-1097741_T1w.nii.gz  # Poor data quality at C2-3
 - sub-1098459_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1102439_T1w.nii.gz  # Motion artefact  
 - sub-1113753_T1w.nii.gz  # Motion artefact
@@ -68,7 +72,10 @@
 - sub-1123856_T1w.nii.gz  # Motion artefact
 - sub-1125665_T1w.nii.gz  # Motion artefact
 - sub-1127471_T1w.nii.gz  # Motion artefact + poor data quality
+- sub-1132109_T1w.nii.gz  # Poor data quality
 - sub-1132220_T1w.nii.gz  # Motion artefact
+- sub-1132718_T1w.nii.gz  # Poor data quality
+- sub-1133024_T1w.nii.gz  # Poor data quality
 - sub-1133658_T1w.nii.gz  # Motion artefact
 - sub-1136053_T1w.nii.gz  # Motion artefact + poor data quality
 - sub-1139207_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3
@@ -76,3 +83,4 @@
 - sub-1139906_T1w.nii.gz  # Poor data quality just bellow C2-3
 - sub-1140969_T1w.nii.gz  # Poor data quality at C2-3 disc
 - sub-1141536_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1117152_T1w.nii.gz  # FOV cuts just below C2-3 + image tilted


### PR DESCRIPTION
## Description
This PR adds subjects to exclude in `exclude.yml`. The main causes for exclusion are that the FOV doesn't cover C2-C3 and poor data quality.
I observed the following artefact multiple times:
(sub-1132718_T1w.nii.gz)
![image](https://user-images.githubusercontent.com/71230552/114456851-5b652400-9bab-11eb-9d97-139d3b143501.png)
![image](https://user-images.githubusercontent.com/71230552/114456917-6cae3080-9bab-11eb-8003-649e357e3349.png)

I am not sure what could be the cause here.