### PR TITLE
Update installation instructions for `gradunwarp` and SCT v5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This repository includes a collection of scripts to analyse a BIDS-structured MR
 MANDATORY:
 
 * [SCT 5.3.0](https://github.com/neuropoly/spinalcordtoolbox/releases/tag/5.3.0) for processing
-* [gradunwrap v1.2.0](https://github.com/Washington-University/gradunwarp/tree/v1.2.0) for gradient correction
+* [gradunwarp](gradunwarp_installation.md) for gradient correction
 * [ANTs](https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS) for processing
 * Python 3.7  for statistical analysis
 
@@ -111,7 +111,7 @@ cd ukbiobank-spinalcord-csa
 pip install -e ./
 ~~~
 #### Note on gradient distortion correction
-A `coeff.grad` associated with the MRI scanner used for the data is necessary if it has not been applied yet. In this project, the gradient distortion correction is done in `preprocess_data.sh` with [gradunwrap v1.2.0](https://github.com/Washington-University/gradunwarp/tree/v1.2.0) and Siemens `coeff.grad` file.
+A `coeff.grad` associated with the MRI scanner used for the data is necessary if it has not been applied yet. In this project, the gradient distortion correction is done in `preprocess_data.sh` with `gradunwarp` and Siemens `coeff.grad` file.
 - - -
 ### Preprocessing
 Preprocessing generates a dataset with gradient distortion correction. 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This repository includes a collection of scripts to analyse a BIDS-structured MR
 ### Dependencies
 MANDATORY:
 
-* [SCT 5.0.1](https://github.com/neuropoly/spinalcordtoolbox/releases/tag/5.0.1) for processing
+* [SCT 5.3.0](https://github.com/neuropoly/spinalcordtoolbox/releases/tag/5.3.0) for processing
 * [gradunwrap v1.2.0](https://github.com/Washington-University/gradunwarp/tree/v1.2.0) for gradient correction
 * [ANTs](https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS) for processing
 * Python 3.7  for statistical analysis

--- a/gradunwarp_installation.md
+++ b/gradunwarp_installation.md
@@ -1,0 +1,33 @@
+### How to install gradunwarp
+
+We recommend that you **do not** follow the default installation instructions for `gradunwarp`, due to the reasons outlined [here](https://github.com/sct-pipeline/ukbiobank-spinalcord-csa/issues/31).
+
+Instead, we provide our own set of steps to help make the installation process smoother.
+
+1. Install the dependencies of `gradunwarp`
+
+```bash
+pip install numpy scipy nibabel
+```
+
+2. Download and extract the [latest release](https://github.com/Washington-University/gradunwarp/releases/latest) of `gradunwarp`
+   
+
+3. Navigate to the extracted folder, then install `gradunwarp`
+
+```bash
+cd gradunwarp-1.2.0/
+python setup.py install --prefix="~/.local"
+```
+
+4. Update your `$PATH` to include the installation location
+
+```bash
+# For bash users
+echo "export PATH=$PATH:~/.local/bin" >> ~/.bashrc
+
+# For zsh users
+echo "export PATH=$PATH:~/.local/bin" >> ~/.zshrc
+```
+   
+5. You're done! The command `gradient_unwarp.py` should now be available in your terminal after restarting the terminal.


### PR DESCRIPTION
### Description

SCT v5.3.0 includes a better fix for the `gradunwarp` installation issue. So, this PR:

* Updates the version of SCT
* Provides an alternate set of installation instructions for `gradunwarp` that are less error prone.

I've put the alternate instructions in a separate `.md` file for now, but they might be better off in another location. (Up to you @sandrinebedard!)

### Linked issues
Fixes #31.
Fixes #58.
Fixes #18 