### PR TITLE
Add subjects with wrong FOV to exclude.yml

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -1,6 +1,8 @@
+- sub-1000394_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1005491_T2w.nii.gz  # Don't see C2-3 disc, image tilted
 - sub-1006023_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc 
 - sub-1007450_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1007915_T1w.nii.gz  # FOV cuts at C2-C
 - sub-1007915_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1010982_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc --> automatic defacing problem
 - sub-1011687_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
@@ -15,6 +17,7 @@
 - sub-1018932_T1w.nii.gz  # Poor contrast of SC arround C2-C3 + image tilted
 - sub-1018932_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1019867_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1021125_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1021125_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1021191_T1w.nii.gz  # Motion artifact
 - sub-1021534_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
@@ -27,6 +30,7 @@
 - sub-1026594_T2w.nii.gz  # No contrast arround SC at C2-C3
 - sub-1027132_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1027567_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1028228_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1029324_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1029729_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1029993_T1w.nii.gz  # FOV cuts before C2-C3 disc
@@ -35,12 +39,15 @@
 - sub-1031426_T1w.nii.gz  # Motion artifact
 - sub-1031426_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1031952_T2w.nii.gz  # Image tilted + shading, don't see SC + disc
+- sub-1035680_T1w.nii.gz  # Bad data quality arround C2-3 + FOV cuts at C2-3
 - sub-1035680_T2w.nii.gz  # Shading at C2-C3
 - sub-1035863_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1036209_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1036337_T2w.nii.gz  # FOV cuts SC
+- sub-1036523_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1036523_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1036748_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
-- sub-1035680_T1w.nii.gz  # Bad data quality arround C2-3 + FOV cuts at C2-3
+- sub-1038735_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1038735_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1039751_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1040099_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
@@ -51,9 +58,12 @@
 - sub-1047654_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1048407_T1w.nii.gz  # Poor data quality
 - sub-1048812_T1w.nii.gz  # Motion artifact
+- sub-1050166_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1052980_T1w.nii.gz  # Poor data quality
 - sub-1052029_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1058390_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1059011_T1w.nii.gz  # Motion artifact
+- sub-1064870_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1067736_T1w.nii.gz  # Motion artifact
 - sub-1070818_T1w.nii.gz  # Motion artifact + poor data quality
 - sub-1077193_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3


### PR DESCRIPTION
## Description
This PR adds subjects with FOV that cuts C2-C3 disc to `exclude.yml` .
 E.g.: 
![image](https://user-images.githubusercontent.com/71230552/118138665-9b027400-b3d4-11eb-8aea-163284bd6068.png)


