### PR TITLE
Add subjects with wrong FOV to exclude.yml

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -38,11 +38,13 @@
 - sub-1030519_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1031426_T1w.nii.gz  # Motion artifact
 - sub-1031426_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1031952_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1031952_T2w.nii.gz  # Image tilted + shading, don't see SC + disc
 - sub-1035680_T1w.nii.gz  # Bad data quality arround C2-3 + FOV cuts at C2-3
 - sub-1035680_T2w.nii.gz  # Shading at C2-C3
 - sub-1035863_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1036209_T1w.nii.gz  # FOV cuts at C2-C3
+- sub-1036337_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1036337_T2w.nii.gz  # FOV cuts SC
 - sub-1036523_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1036523_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
@@ -65,36 +67,63 @@
 - sub-1058390_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1059011_T1w.nii.gz  # Motion artifact
 - sub-1064870_T1w.nii.gz  # FOV cuts at C2-C3
+- sub-1065847_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1067736_T1w.nii.gz  # Motion artifact
+- sub-1070750_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1070818_T1w.nii.gz  # Motion artifact + poor data quality
+- sub-1070924_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1077193_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3
 - sub-1078395_T1w.nii.gz  # Motion artifact
+- sub-1079946_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1080952_T1w.nii.gz  # Motion artifact
 - sub-1081070_T1w.nii.gz  # Motion artifact
+- sub-1082019_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1082225_T1w.nii.gz  # Motion artifact
+- sub-1083077_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1089301_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1089378_T1w.nii.gz  # FOV just below C2-C3
+- sub-1089633_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1090864_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1091250_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1094289_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1096007_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1097616_T1w.nii.gz  # Motion artifact
 - sub-1097677_T1w.nii.gz  # Motion artifact
+- sub-1098396_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1098459_T1w.nii.gz  # FOV cuts C2-C3 disc
-- sub-1102439_T1w.nii.gz  # Motion artifact  
+- sub-1100952_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1102439_T1w.nii.gz  # Motion artifact
+- sub-1103629_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1106613_T1w.nii.gz  # FOV cuts C2-C3 disc  
+- sub-1107534_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1112791_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1113167_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1113753_T1w.nii.gz  # Motion artifact
 - sub-1114977_T1w.nii.gz  # FOV cuts C2-C3 + poor data quality
 - sub-1115141_T1w.nii.gz  # Poor data quality
 - sub-1117152_T1w.nii.gz  # FOV cuts just below C2-3 + image tilted
+- sub-1118280_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1120512_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1122338_T1w.nii.gz  # Motion artifact
+- sub-1123222_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1123520_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1123856_T1w.nii.gz  # Motion artifact
+- sub-1124777_T1w.nii.gz  # FOV cuts just below C2-C3 + motion
 - sub-1125665_T1w.nii.gz  # Motion artifact
 - sub-1127471_T1w.nii.gz  # Motion artifact + poor data quality
+- sub-1128336_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1130923_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1132220_T1w.nii.gz  # Motion artifact
 - sub-1133024_T1w.nii.gz  # Poor data quality + motion
 - sub-1133658_T1w.nii.gz  # Motion artifact
 - sub-1134671_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1136053_T1w.nii.gz  # Motion artifact + poor data quality
 - sub-1137171_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1138467_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1139207_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3
 - sub-1139656_T1w.nii.gz  # Poor data quality arround C2-C3
 - sub-1139906_T1w.nii.gz  # Poor data quality just bellow C2-3
+- sub-1140271_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1140969_T1w.nii.gz  # Poor data quality at C2-3 disc
 - sub-1141536_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1141608_T1w.nii.gz  # FOV cuts C2-C3 disc


### PR DESCRIPTION
## Description
This PR adds subjects with a FOV that cuts C2-C3 disc to `exclude.yml`. 

All vertebral labels and segmentations are manually qc-ed for the first 1000 subjects of UK Biobank. We have a total of 88 T1w images to exclude.