### PR TITLE
Add images with motion artifacts to exclude.yml

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -1,6 +1,7 @@
 - sub-1000394_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1005491_T2w.nii.gz  # Don't see C2-3 disc, image tilted
 - sub-1006023_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc 
+- sub-1006510_T1w.nii.gz  # Motion artifact
 - sub-1007450_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1007915_T1w.nii.gz  # FOV cuts at C2-C
 - sub-1007915_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
@@ -8,6 +9,7 @@
 - sub-1011687_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1012113_T1w.nii.gz  # FOV cuts before C2-C3 disc
 - sub-1012113_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1015206_T1w.nii.gz  # Motion artifact
 - sub-1015344_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1016730_T1w.nii.gz  # Image tilted + poor contrast at C2-C3 of SC
 - sub-1016730_T2w.nii.gz  # Shading arround C2-C3, can't see SC
@@ -21,6 +23,7 @@
 - sub-1021125_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1021191_T1w.nii.gz  # Motion artifact
 - sub-1021534_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1021716_T1w.nii.gz  # Motion artefact
 - sub-1022232_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1023062_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1024269_T1w.nii.gz  # Motion artifact
@@ -28,6 +31,7 @@
 - sub-1024889_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1024269_T1w.nii.gz  # SC is blured and FOV cuts at C2-C3 disc
 - sub-1026594_T2w.nii.gz  # No contrast arround SC at C2-C3
+- sub-1026648_T1w_nii.gz  # Motion artifact
 - sub-1027132_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1027567_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1028228_T1w.nii.gz  # FOV cuts at C2-C3
@@ -52,15 +56,21 @@
 - sub-1038735_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1038735_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1039751_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1039910_T1w.nii.gz  # Motion artifact
 - sub-1040099_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1040988_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1041093_T1w.nii.gz  # Motion artifact + poor data quality
 - sub-1041624_T2w.nii.gz  # Shading of SC, don't see SC + disc
+- sub-1042975_T1w.nii.gz  # Motion artifact
 - sub-1043645_T1w.nii.gz  # Motion artifact
 - sub-1045181_T2w.nii.gz  # Shading + poor data quality
 - sub-1046534_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
+- sub-1047359_T1w.nii.gz  # Motion artifact
 - sub-1047654_T2w.nii.gz  # Shading at C2-C3, don't see SC + disc
 - sub-1048407_T1w.nii.gz  # Poor data quality
+- sub-1048637_T1w.nii.gz  # Motion artifact
 - sub-1048812_T1w.nii.gz  # Motion artifact
+- sub-1050042_T1w.nii.gz  # Motion artifact
 - sub-1050166_T1w.nii.gz  # FOV cuts at C2-C3
 - sub-1052980_T1w.nii.gz  # Poor data quality
 - sub-1052029_T1w.nii.gz  # FOV cuts C2-C3 disc
@@ -72,14 +82,19 @@
 - sub-1070750_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1070818_T1w.nii.gz  # Motion artifact + poor data quality
 - sub-1070924_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1073057_T1w.nii.gz  # Motion artifact
 - sub-1077193_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3
+- sub-1077469_T1w.nii.gz  # Motion artifact
 - sub-1078395_T1w.nii.gz  # Motion artifact
+- sub-1078726_T1w.nii.gz  # Motion artifact
 - sub-1079946_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1080952_T1w.nii.gz  # Motion artifact
 - sub-1081070_T1w.nii.gz  # Motion artifact
 - sub-1082019_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1082225_T1w.nii.gz  # Motion artifact
 - sub-1083077_T1w.nii.gz  # FOV cuts C2-C3 disc
+- sub-1085173_T1w.nii.gz  # Motion artifact
+- sub-1087397_T1w.nii.gz  # Motion artifact
 - sub-1089301_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1089378_T1w.nii.gz  # FOV just below C2-C3
 - sub-1089633_T1w.nii.gz  # FOV cuts just below C2-C3
@@ -92,6 +107,8 @@
 - sub-1098396_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1098459_T1w.nii.gz  # FOV cuts C2-C3 disc
 - sub-1100952_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1101310_T1w.nii.gz  # Motion artifact
+- sub-1102364_T1w.nii.gz  # Motion artifact
 - sub-1102439_T1w.nii.gz  # Motion artifact
 - sub-1103629_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1106613_T1w.nii.gz  # FOV cuts C2-C3 disc  
@@ -118,7 +135,10 @@
 - sub-1133024_T1w.nii.gz  # Poor data quality + motion
 - sub-1133658_T1w.nii.gz  # Motion artifact
 - sub-1134671_T1w.nii.gz  # FOV cuts just below C2-C3
+- sub-1135218_T1w.nii.gz  # Motion artifact
+- sub-1135714_T1w.nii.gz  # Motion artifact
 - sub-1136053_T1w.nii.gz  # Motion artifact + poor data quality
+- sub-1136342_T1w.nii.gz  # Motion artifact
 - sub-1137171_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1138467_T1w.nii.gz  # FOV cuts just below C2-C3
 - sub-1139207_T1w.nii.gz  # Poor data quality + FOV cuts just below C2-3


### PR DESCRIPTION
## Description
This PR adds subjects to exclude due to motion artifacts to `exclude.yml`.

Example:
![image](https://user-images.githubusercontent.com/71230552/120363088-bf69b600-c2d9-11eb-95c5-26f0924ed9a3.png)

![image](https://user-images.githubusercontent.com/71230552/120363063-b973d500-c2d9-11eb-984d-0bd839fa086c.png)
