### PR TITLE
Add pmj labeling and CSA from PMJ in processing pipeline

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -107,7 +107,15 @@ sct_qc -i ${file_t1}.nii.gz -s ${file_t1_seg_labeled}.nii.gz -p sct_label_verteb
 # Flatten scan along R-L direction (to make nice figures)
 sct_flatten_sagittal -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz
 # Compute average cord CSA between C2 and C3
-sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile ${file_t1_seg_labeled}.nii.gz -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
+sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile ${file_t1_seg_labeled}.nii.gz -o ${PATH_RESULTS}/csa-SC_c2c3.csv -append 1
+
+# Detect PMJ
+sct_detect_pmj -i ${file_t1}.nii.gz -c t1 -s ${file_t1_seg}.nii.gz -qc ${PATH_QC}
+# Compute average cord CSA from 60 mm of PMJ
+sct_process_segmentation -i ${file_t1_seg}.nii.gz -pmj ${file_t1}_pmj.nii.gz -distance 60 -o ${PATH_RESULTS}/csa-SC_pmj.csv -append 1
+
+# Smooth extrapolated centerline in R-L direction (for visualization)
+sct_maths -i ${file_t1_seg}_centerline_extrapolated.nii.gz -smooth 10,1,1 -o ${file_t1_seg}_centerline_extrapolated_s.nii.gz
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------

--- a/process_data.sh
+++ b/process_data.sh
@@ -109,10 +109,9 @@ sct_flatten_sagittal -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz
 # Compute average cord CSA between C2 and C3
 sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile ${file_t1_seg_labeled}.nii.gz -o ${PATH_RESULTS}/csa-SC_c2c3.csv -append 1
 
-
 # Detect PMJ
 sct_detect_pmj -i ${file_t1}.nii.gz -c t1 -s ${file_t1_seg}.nii.gz -qc ${PATH_QC}
-# Compute average cord CSA from 60 mm of PMJ
+# Compute average cord CSA 60 mm of PMJ
 sct_process_segmentation -i ${file_t1_seg}.nii.gz -pmj ${file_t1}_pmj.nii.gz -distance 60 -o ${PATH_RESULTS}/csa-SC_pmj.csv -append 1
 
 # Smooth extrapolated centerline in R-L direction (for visualization)

--- a/process_data.sh
+++ b/process_data.sh
@@ -85,7 +85,7 @@ detect_pmj_if_does_not_exist(){
 
   else
     echo "Not found. Proceeding with automatic labeling."
-    # Detetct PMJ
+    # Detect PMJ
     sct_detect_pmj -i ${file}.nii.gz -c t1 -s ${file_seg}.nii.gz -qc ${PATH_QC}
   fi
 }

--- a/process_data.sh
+++ b/process_data.sh
@@ -109,6 +109,7 @@ sct_flatten_sagittal -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz
 # Compute average cord CSA between C2 and C3
 sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile ${file_t1_seg_labeled}.nii.gz -o ${PATH_RESULTS}/csa-SC_c2c3.csv -append 1
 
+
 # Detect PMJ
 sct_detect_pmj -i ${file_t1}.nii.gz -c t1 -s ${file_t1_seg}.nii.gz -qc ${PATH_QC}
 # Compute average cord CSA from 60 mm of PMJ


### PR DESCRIPTION
## Description
This PR adds processing steps to compute CSA based on a distance from PMJ (see #78).

It includes:

- Detect PMJ if manual label does not already exists
- Call `sct_process_segmentation` with flag `pmj` at 60 mm from PMJ with default extent of 20 mm
- Smooth extrapolated centerline in R-L direction (for visualization)

## Linked issue
Closes #78 