### PR TITLE
Add statistics for PMJ-based CSA and compute distance from C2-C3 and PMJ

### DIFF
--- a/get_distance_pmj_disc.py
+++ b/get_distance_pmj_disc.py
@@ -40,7 +40,7 @@ def get_distance_from_pmj(centerline_points, z_index, px, py, pz):
     """
     Compute distance from projected PMJ on centerline and cord centerline.
     :param centerline_points: 3xn array: Centerline in continuous coordinate (float) for each slice in RPI orientation.
-    :param z_index: z index of projected PMJ on the centerline.
+    :param z_index: z index PMJ on the centerline.
     :param px: x pixel size.
     :param py: y pixel size.
     :param pz: z pixel size.
@@ -68,11 +68,15 @@ def main():
     px = dim[0]
     py = dim[1]
     pz = dim[2]
+    # Create an array with centerline coordinates
     centerline = np.genfromtxt(args.centerline, delimiter=',')
+    # Get C2-C3 disc coordinate
     c2_c3_disc = np.argwhere(disc_label.get_fdata() == 3)[0]
-    arr_distance = get_distance_from_pmj(centerline, int(centerline[2].max()), px, py, pz)
-
-    distance_disc_pmj = arr_distance[:, c2_c3_disc[-1]][0]
+    # Compute distance from PMJ of the centerline
+    arr_distance = get_distance_from_pmj(centerline, centerline[2].argmax(), px, py, pz)
+    # Get the index of centerline array of c2c3 disc
+    c2c3_index = np.abs(centerline[2] - c2_c3_disc[-1]).argmin()  # centerline doesn't necessarly start at the index 0 if the segmentation is incomplete
+    distance_disc_pmj = arr_distance[:, c2c3_index][0]
     subject = os.path.basename(args.disclabel).split('_')[0]
 
     fname_out = args.o

--- a/get_distance_pmj_disc.py
+++ b/get_distance_pmj_disc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
-# Add padding to an image by mirring the image
+# Add padding to an image by mirroring the image
 #
 # For usage, type: python get_distance_pmj_dics -h
 

--- a/get_distance_pmj_disc.py
+++ b/get_distance_pmj_disc.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# Add padding to an image by mirring the image
+#
+# For usage, type: python get_distance_pmj_dics -h
+
+# Authors: Sandrine Bédard
+
+import argparse
+import csv
+from operator import sub
+import numpy as np
+import nibabel as nib
+import os
+
+NEAR_ZERO_THRESHOLD = 1e-6
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Compute distance between C2-C3 intervertebral disc and PMJ. Outputs .csv file with results. | Orientation needs to be RPI" )
+    parser.add_argument('-centerline', required=True, type=str,
+                        help="Input image.")
+    parser.add_argument('-disclabel', required=True, type=str,
+                        help="Ouput image.")
+    parser.add_argument('-o', required=False, type=str,
+                        default='pmj_disc_distance.csv',
+                        help="Ouput csv filename.")
+
+    return parser
+
+
+def save_Nifti1(data, original_image, filename):
+    empty_header = nib.Nifti1Header()
+    image = nib.Nifti1Image(data, original_image.affine, empty_header)
+    nib.save(image, filename)
+
+
+def get_distance_from_pmj(centerline_points, z_index, px, py, pz):
+    """
+    Compute distance from projected PMJ on centerline and cord centerline.
+    :param centerline_points: 3xn array: Centerline in continuous coordinate (float) for each slice in RPI orientation.
+    :param z_index: z index of projected PMJ on the centerline.
+    :param px: x pixel size.
+    :param py: y pixel size.
+    :param pz: z pixel size.
+    :return: nd-array: distance from PMJ and corresponding indexes.
+    """
+    length = 0
+    arr_length = [0]
+    for i in range(z_index, 0, -1):
+        distance = np.sqrt(((centerline_points[0, i] - centerline_points[0, i - 1]) * px) ** 2 +
+                           ((centerline_points[1, i] - centerline_points[1, i - 1]) * py) ** 2 +
+                           ((centerline_points[2, i] - centerline_points[2, i - 1]) * pz) ** 2)
+        length += distance
+        arr_length.append(length)
+    arr_length = arr_length[::-1]
+    arr_length = np.stack((arr_length, centerline_points[2][:z_index + 1]), axis=0)
+    return arr_length
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    disc_label = nib.load(args.disclabel)
+    dim = disc_label.header['pixdim']
+    px = dim[0]
+    py = dim[1]
+    pz = dim[2]
+    centerline = np.genfromtxt(args.centerline, delimiter=',')
+    c2_c3_disc = np.argwhere(disc_label.get_fdata() == 3)[0]
+    arr_distance = get_distance_from_pmj(centerline, int(centerline[2].max()), px, py, pz)
+
+    distance_disc_pmj = arr_distance[:, c2_c3_disc[-1]][0]
+    subject = os.path.basename(args.disclabel).split('_')[0]
+
+    fname_out = args.o
+    if not os.path.isfile(fname_out):
+        with open(fname_out, '') as csvfile:
+            header = ['Subject', 'C2C3_distance_PMJ']
+            writer = csv.DictWriter(csvfile, fieldnames=header)
+            writer.writeheader()
+    with open(fname_out, 'a') as csvfile:
+        spamwriter = csv.writer(csvfile, delimiter=',')
+        line = [subject, distance_disc_pmj]
+        spamwriter.writerow(line)
+
+
+if __name__ == '__main__':
+    main()

--- a/get_distance_pmj_disc.py
+++ b/get_distance_pmj_disc.py
@@ -77,7 +77,7 @@ def main():
 
     fname_out = args.o
     if not os.path.isfile(fname_out):
-        with open(fname_out, '') as csvfile:
+        with open(fname_out, 'w') as csvfile:
             header = ['Subject', 'C2C3_distance_PMJ']
             writer = csv.DictWriter(csvfile, fieldnames=header)
             writer.writeheader()

--- a/pipeline_ukbiobank/cli/compute_stats.py
+++ b/pipeline_ukbiobank/cli/compute_stats.py
@@ -248,7 +248,7 @@ def scatter_plot_pmj_c2c3(x, y, path):
              ha='left', va='center', color='crimson', transform=ax.transAxes,
              fontsize=12,
              bbox=dict(boxstyle='round', facecolor='white', alpha=1))  # box around equation
-    # PLot linear regression
+    # Plot linear regression
     axes = plt.gca()
     x_vals = np.array(axes.get_xlim())
     y_vals = model.params[0] + model.params[1] * x_vals
@@ -259,6 +259,26 @@ def scatter_plot_pmj_c2c3(x, y, path):
     plt.savefig(os.path.join(path, filename))
     logger.info('Created: ' + filename)
     plt.close()
+
+
+def analyse_distance_c2c3_pmj(distance, path):
+    """
+    Generate and save a scatter plot of distance, compute mean and std.
+    """
+    mean = np.mean(distance)
+    std = np.std(distance)
+    plt.figure()
+    fig, ax = plt.subplots()
+    sns.scatterplot(data=distance, alpha=0.7, edgecolors=None, linewidth=0)
+    plt.axhline(y=mean, linewidth=2, color='k', ls="--")
+    plt.ylabel('Distance from PMJ and C2-C3 disc (mm)')
+    plt.title('Distance from PMJ and C2-C3')
+    filename = 'scatterplot_c2c3_pmj_distance.png'
+    plt.savefig(os.path.join(path, filename))
+    logger.info('Created: ' + filename)
+    plt.close()
+
+    logger.info('Mean distance from PMJ to C2-C3 disc is {} mm and standard deviation is {} mm'.format(format_number(mean), format_number(std)))
 
 
 def df_to_csv(df, filename):
@@ -739,6 +759,9 @@ def main():
     if not os.path.exists(path_scatter_plot_c2c3_pmj):
         os.mkdir(path_scatter_plot_c2c3_pmj)
     scatter_plot_pmj_c2c3(df['CSA_pmj'], df['CSA_c2c3'], path_scatter_plot_c2c3_pmj)
+
+    # Generate scatter plot of distance between PMJ and C2-C3 disc
+    analyse_distance_c2c3_pmj(df['distance_c2c3_pmj'], path_scatter_plot_c2c3_pmj)
 
     # Stepwise linear regression and complete linear regression for PMJ-based CSA
     x = df.drop(columns=['CSA_c2c3', 'CSA_pmj'])  # Initialize x to data of predictors

--- a/pipeline_ukbiobank/cli/compute_stats.py
+++ b/pipeline_ukbiobank/cli/compute_stats.py
@@ -272,26 +272,6 @@ def scatter_plot_pmj_c2c3(x, y, distance, path):
     plt.close()
 
 
-def analyse_distance_c2c3_pmj(distance, path):
-    """
-    Generate and save a scatter plot of distance, compute mean and std.
-    """
-    mean = np.mean(distance)
-    std = np.std(distance)
-    plt.figure()
-    fig, ax = plt.subplots()
-    sns.scatterplot(data=distance, alpha=0.7, edgecolors=None, linewidth=0)
-    plt.axhline(y=mean, linewidth=2, color='k', ls="--")
-    plt.ylabel('Distance from PMJ and C2-C3 disc (mm)')
-    plt.title('Distance from PMJ and C2-C3')
-    filename = 'scatterplot_c2c3_pmj_distance.png'
-    plt.savefig(os.path.join(path, filename))
-    logger.info('Created: ' + filename)
-    plt.close()
-
-    logger.info('Mean distance from PMJ to C2-C3 disc is {} mm and standard deviation is {} mm'.format(format_number(mean), format_number(std)))
-
-
 def df_to_csv(df, filename):
     """
     Save a Dataframe as a .csv file.

--- a/pipeline_ukbiobank/cli/get_subject_info.py
+++ b/pipeline_ukbiobank/cli/get_subject_info.py
@@ -161,6 +161,7 @@ def main():
 
     # Initialize name of csv file of CSA in results folder
     path_csa_c2c3 = os.path.join(path_results, 'csa-SC_c2c3.csv')
+    path_csa_pmj = os.path.join(path_results, 'csa-SC_pmj.csv')
 
     # Set the index of the dataFrame to 'Subject'
     df = df.set_index('Subject')
@@ -170,11 +171,14 @@ def main():
     # Sum right and left thalamus volume
     compute_total_thalamus_volume(df)
 
-    # Get csa values for T1w
+    # Get csa values for T1w at C2-C3 and PMJ-based
     csa_c2c3 = get_csa(path_csa_c2c3)
+    csa_pmj = get_csa(path_csa_pmj)
 
     # Add column to dataFrame of CSA values for T1w for each subject
     append_csa_to_df(df, csa_c2c3, 'CSA_c2c3')
+    append_csa_to_df(df, csa_pmj, 'CSA_pmj')
+
     # Write a .csv file in <path_results/results> folder
     filename = 'data_ukbiobank.csv'
     df.to_csv(os.path.join(path_results, filename))

--- a/pipeline_ukbiobank/cli/get_subject_info.py
+++ b/pipeline_ukbiobank/cli/get_subject_info.py
@@ -162,6 +162,7 @@ def main():
     # Initialize name of csv file of CSA in results folder
     path_csa_c2c3 = os.path.join(path_results, 'csa-SC_c2c3.csv')
     path_csa_pmj = os.path.join(path_results, 'csa-SC_pmj.csv')
+    path_distance_c2c3_pmj = os.path.join(path_results, 'c2c3_pmj_distance.csv')
 
     # Set the index of the dataFrame to 'Subject'
     df = df.set_index('Subject')
@@ -175,7 +176,11 @@ def main():
     csa_c2c3 = get_csa(path_csa_c2c3)
     csa_pmj = get_csa(path_csa_pmj)
 
+    # Get distance of C2-C2 from PMJ
+    distance_c2c3_pmj = csv2dataFrame(path_distance_c2c3_pmj)
+
     # Add column to dataFrame of CSA values for T1w for each subject
+    append_csa_to_df(df, distance_c2c3_pmj, 'distance_c2c3_pmj')
     append_csa_to_df(df, csa_c2c3, 'CSA_c2c3')
     append_csa_to_df(df, csa_pmj, 'CSA_pmj')
 

--- a/pipeline_ukbiobank/cli/get_subject_info.py
+++ b/pipeline_ukbiobank/cli/get_subject_info.py
@@ -91,7 +91,7 @@ def get_csa(csa_filename):
     return csa
 
 
-def append_csa_to_df(df, csa, column_name):
+def append_csa_to_df(df, csa, new_column_name, old_column_name):
     """
     Adds CSA values to dataframe for each subjects.
     Args:
@@ -104,7 +104,7 @@ def append_csa_to_df(df, csa, column_name):
         # For subjects that have csa values,
         if subject in csa.index:
             # Set csa value for the subject
-            df.loc[subject, column_name] = csa.loc[subject, 'MEAN(area)']
+            df.loc[subject, new_column_name] = csa.loc[subject, old_column_name]
 
 
 def compute_total_thalamus_volume(df):
@@ -177,12 +177,12 @@ def main():
     csa_pmj = get_csa(path_csa_pmj)
 
     # Get distance of C2-C2 from PMJ
-    distance_c2c3_pmj = csv2dataFrame(path_distance_c2c3_pmj)
+    distance_c2c3_pmj = (csv2dataFrame(path_distance_c2c3_pmj)).set_index('Subject')
 
     # Add column to dataFrame of CSA values for T1w for each subject
-    append_csa_to_df(df, distance_c2c3_pmj, 'distance_c2c3_pmj')
-    append_csa_to_df(df, csa_c2c3, 'CSA_c2c3')
-    append_csa_to_df(df, csa_pmj, 'CSA_pmj')
+    append_csa_to_df(df, distance_c2c3_pmj, 'distance_c2c3_pmj', 'C2C3_distance_PMJ')
+    append_csa_to_df(df, csa_c2c3, 'CSA_c2c3', 'MEAN(area)')
+    append_csa_to_df(df, csa_pmj, 'CSA_pmj', 'MEAN(area)')
 
     # Write a .csv file in <path_results/results> folder
     filename = 'data_ukbiobank.csv'

--- a/pipeline_ukbiobank/cli/get_subject_info.py
+++ b/pipeline_ukbiobank/cli/get_subject_info.py
@@ -160,7 +160,7 @@ def main():
         df[param] = raw_data[key]
 
     # Initialize name of csv file of CSA in results folder
-    path_csa_t1w = os.path.join(path_results, 'csa-SC_T1w.csv')
+    path_csa_c2c3 = os.path.join(path_results, 'csa-SC_c2c3.csv')
 
     # Set the index of the dataFrame to 'Subject'
     df = df.set_index('Subject')
@@ -171,10 +171,10 @@ def main():
     compute_total_thalamus_volume(df)
 
     # Get csa values for T1w
-    csa_t1w = get_csa(path_csa_t1w)
+    csa_c2c3 = get_csa(path_csa_c2c3)
 
     # Add column to dataFrame of CSA values for T1w for each subject
-    append_csa_to_df(df, csa_t1w, 'T1w_CSA')
+    append_csa_to_df(df, csa_c2c3, 'CSA_c2c3')
     # Write a .csv file in <path_results/results> folder
     filename = 'data_ukbiobank.csv'
     df.to_csv(os.path.join(path_results, filename))

--- a/process_data.sh
+++ b/process_data.sh
@@ -20,6 +20,9 @@ trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
 # Retrieve input params
 SUBJECT=$1
 
+# Save script path
+PATH_SCRIPT=$PWD
+
 # get starting time:
 start=`date +%s`
 
@@ -136,6 +139,9 @@ sct_process_segmentation -i ${file_t1_seg}.nii.gz -pmj ${file_t1}_pmj.nii.gz -di
 
 # Smooth extrapolated centerline in R-L direction (for visualization)
 sct_maths -i ${file_t1_seg}_centerline_extrapolated.nii.gz -smooth 10,1,1 -o ${file_t1_seg}_centerline_extrapolated_s.nii.gz
+
+# Compute distance between PMJ and C2-C3 intervertebral disc
+python $PATH_SCRIPT/get_distance_pmj_disc.py -centerline centerline.csv -disclabel ${file_t1_seg}_labeled_discs.nii.gz -o ${PATH_RESULTS}/c2c3_pmj_distance.csv
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
This PR addresses #83 and #84. 
Main changes include:
#### In `process_data.sh`:
* Compute distance from PMJ along extrapolated centerline from C2-C3 disc with the script `get_distance_pmj_disc.py`, save in a .csv file

To to this, I added the saving of the centerline coordinates since it is more precise than in the image of centerline_extrapolated --> https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3478/commits/79752f834c9cb54b6a8b244068f1556a61dd8f75 

#### In `get_subject_info.py`:
* Read PMJ-based CSA and a column for it
* Read distance from PMJ and C2-C3 disc and add a column for it

#### In `compute_stats.py`:
* Compute mean, std, median, COV for both CSA measures
* Compute regression, normalization only with PMJ-based CSA
* Add scatter plot for C2-C3-based CSA vs PMJ-based CSA
* Add scatter plot for distance from PMJ and C2-C3 disc
![image](https://user-images.githubusercontent.com/71230552/126523481-d24529ab-d3f6-48c3-abd7-186f036f10b6.png)

## Linked issues
Resolves #84 and Resolves #83 